### PR TITLE
Added missing metadata to the body

### DIFF
--- a/examples/charges/subscription/createOneStepBilletSubscription.php
+++ b/examples/charges/subscription/createOneStepBilletSubscription.php
@@ -49,6 +49,7 @@ $customer = [
 
 $body = [
 	"items" => $items,
+	"metadata" => $metadata,
 	"payment" => [
 		"banking_billet" => [
 			"expire_at" => "2024-12-10",


### PR DESCRIPTION
The body request was missing the metadata. If used as is then the user would not receive the (webhook) notification.