### PR TITLE
Falha ao gerar o access_token, quando não é encontrado no cache.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.lock
 vendor/
 examples/open-accounts/
+.idea

--- a/src/Efi/ApiRequest.php
+++ b/src/Efi/ApiRequest.php
@@ -45,7 +45,7 @@ class ApiRequest extends BaseModel
         if (!$this->isAccessTokenValid() || !$this->options['cache']) {
             $this->auth->authorize();
         } else {
-            if (in_array($scope, $this->cacheScopes)) {
+            if (in_array($scope, $this->cacheScopes) && $this->cacheAccessToken) {
                 $this->auth->accessToken = $this->cacheAccessToken;
             } else {
                 $this->auth->authorize();


### PR DESCRIPTION
Estava com erro ao tentar criar uma cobrança com o PIX em produção. 

Depois de fazer alguns debugs percebi que o atributo  `$this->cacheAccessToken` estava sem valor.  E não estava sendo carregado o access_token. 