### PR TITLE
feat: fix for exception throwing that occurs when deleting pix code

### DIFF
--- a/src/Efi/Request.php
+++ b/src/Efi/Request.php
@@ -231,7 +231,13 @@ class Request extends BaseModel
     {
         $headersResponse = $this->config['responseHeaders'] ? $response->getHeaders() : $response->getHeader('Content-Type');
 
-        $contentType = isset($headersResponse['Content-Type'][0]) ? $headersResponse['Content-Type'][0] : $headersResponse[0];
+        $contentType = null;
+
+        if(!empty($headersResponse['Content-Type'][0])){
+            $contentType = $headersResponse['Content-Type'][0];
+        }elseif(!empty($headersResponse[0])){
+            $contentType = $headersResponse[0];
+        }
 
         if (stristr($contentType, 'application/json')) {
             $bodyResponse = json_decode($response->getBody(), true);


### PR DESCRIPTION
Ao chamar a função pixDeleteEvp(), nos casos de return 200 ok, o código estava lançando uma Exception, pois não localizava a varíavel "$headersResponse[0]".

**1) O arquivo contendo a varíavel** 
![image](https://github.com/user-attachments/assets/c1d21220-4bec-4143-a436-58312788bffe)

**2) A Exception sendo lançada, apesar do retorno 200 ok**
![image](https://github.com/user-attachments/assets/af9c27cf-ef83-4adb-b1f4-1b75d0246ce4)

-----------------------
SOLUÇÃO

Acrescentar códigos condicionais , checando a existência e ou existência de conteúdo na varíavel, conforme commit abaixo

Feito isso, agora o return 200 ok esta regular