### PR TITLE
🐛 fix: Correct variable names causing errors

### DIFF
--- a/examples/pix/cobv/pixCreateDueCharge.php
+++ b/examples/pix/cobv/pixCreateDueCharge.php
@@ -87,13 +87,13 @@ try {
 
 	$responseBodyPix = (isset($options["responseHeaders"]) && $options["responseHeaders"]) ? $responsePix->body : $responsePix;
 
-	if ($rresponseBodyPix["txid"]) {
+	if ($responseBodyPix["txid"]) {
 		$params = [
 			"id" => $responseBodyPix["loc"]["id"]
 		];
 
 		try {
-			$responseQrcode->body = $api->pixGenerateQRCode($params);
+			$responseQrcode = $api->pixGenerateQRCode($params);
 
 			$responseBodyQrcode = (isset($options["responseHeaders"]) && $options["responseHeaders"]) ? $responseQrcode->body : $responseQrcode;
 


### PR DESCRIPTION
It was not possible to generate a payment with a due date (Pix) due to incorrect variable names.