### PR TITLE
fix: use explicit nullable type for $options in Endpoints::getInstance()

### DIFF
--- a/src/Efi/Endpoints.php
+++ b/src/Efi/Endpoints.php
@@ -32,7 +32,7 @@ class Endpoints
      * @return Endpoints A new instance of the class.
      * @throws Exception When the credentials are not defined.
      */
-    public static function getInstance(array $options = null, ?object $requester = null): Endpoints
+    public static function getInstance(?array $options = null, ?object $requester = null): Endpoints
     {
         if (!isset($options)) {
             throw new Exception('Credenciais Client_Id e Client_Secret não foram definidas corretamente');


### PR DESCRIPTION
## Problem

PHP 8.4 deprecated implicitly nullable typed parameters ([RFC](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)). When a typed parameter has a default value of `null` without an explicit `?` prefix, PHP 8.4 emits a deprecation notice on every call:

```
PHP Deprecated: Efi\Endpoints::getInstance(): Implicitly marking parameter $options as nullable is deprecated,
the explicit nullable type must be used instead in .../Efi/Endpoints.php on line 35
```

This will become a **fatal error in PHP 9.0**.

## Fix

Change `array $options = null` to `?array $options = null` on line 35 of `src/Efi/Endpoints.php`.

```diff
- public static function getInstance(array $options = null, ?object $requester = null): Endpoints
+ public static function getInstance(?array $options = null, ?object $requester = null): Endpoints
```

The behavior is identical — the parameter remains optional and accepts `null`. This is a purely syntactic correction to satisfy PHP 8.4's stricter type declarations.

## Verification

Confirmed this is the **only** occurrence of this pattern in the codebase. All other nullable parameters in the SDK already use the explicit `?type` syntax.

**References:**
- https://php.watch/versions/8.4/implicitly-nullable-types-deprecated
- https://wiki.php.net/rfc/deprecate-implicitly-nullable-types